### PR TITLE
Docker ps does not accept arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ docker run docker.hypernode.com/byteinternet/hypernode-docker:latest
 Get the IP address
 ```bash
 # Find the container ID
-docker ps <docker name>
+docker ps
 # Find the IP address of the container
 docker inspect -f '{{ .NetworkSettings.IPAddress }}' <the container ID>
 ```


### PR DESCRIPTION
Update syntax to reflect docker ps not accepting arguments contrary to what is stated here.