### PR TITLE
fix uid/gid osx docs

### DIFF
--- a/examples/osx_development/README.md
+++ b/examples/osx_development/README.md
@@ -147,7 +147,7 @@ syncs:
     src: './magento'
     sync_excludes: ['vendor', 'var','pub/media/catalog/product/cache','pub/static','pub/media/tmp','dev','generated']
     watch_excludes: ['vendor', 'var','pub/media/catalog/product/cache','pub/static','pub/media/tmp','dev','generated','lib','setup','update','.*/.git', '.*/node_modules'] # Only changes in app and media
-    sync_userid: '1001'
+    sync_userid: '1000'
     notify_terminal: true
     monit_enable: true
     monit_interval: 10

--- a/examples/osx_development/docker-sync.yml
+++ b/examples/osx_development/docker-sync.yml
@@ -5,6 +5,6 @@ options:
 syncs:
   myproject-app-sync: # Unique! Matches volume name in docker-compose.yml
     src: './magento' # Path to  Magento source code for example in IDE (can be anywhere)
-    sync_userid: '1001' # Don't remove!
+    sync_userid: '1000' # Don't remove!
     sync_excludes: ['var/cache','var/session','var/log','var/view_preprocessed'] # Extend for M1 / M2
     watch_excludes: ['var/cache','var/session','var/log','var/view_preprocessed'] # Extend for M1 / M2


### PR DESCRIPTION
Previously the uid/gid was wrongly set to 1001. We switched that back to 1000
to fix that discrepancy, see #15 and https://github.com/ByteInternet/hypernode-docker/issues/28https://github.com/ByteInternet/hypernode-docker/issues/28. The osx docs weren't updated.