### PR TITLE
Update documentation on switching php versions

### DIFF
--- a/Documentation/switching-php-versions.md
+++ b/Documentation/switching-php-versions.md
@@ -3,10 +3,10 @@
 Unlike the [hypernode-vagrant](https://github.com/ByteInternet/hypernode-vagrant) you can not just run `hypernode-switch-php` to change the PHP version. Because there is no systemctl to manage the services other steps must be performed. To switch to a different PHP version run the following commands:
 
 ```bash
-# Edit /etc/my_init.d/60_restart_services.sh to use the correct PHP
-vim /etc/my_init.d/60_restart_services.sh
-# Change the enabled PHP
-update-alternatives --set php $(which php7.1)
-# Restart (all) services
+# Change the version in magweb.json
+jq ".php.version = 7.3" /etc/hypernode/magweb.json > /tmp/magweb.json
+mv /tmp/magweb.json /etc/hypernode/magweb.json
+
+# Restart all services
 bash /etc/my_init.d/60_restart_services.sh
 ``` 


### PR DESCRIPTION
The documentation on switching php versions has gotten out of date. 

A simple `update-alternatives set --php 7.3` followed by `bash /etc/my_init.d/60_restart_services.sh` will not cut it anymore.

That is, because `/etc/my_init.d/60_restart_services.sh` now runs `update-alternatives set --php ${PHP_VERSION}`. It fetches the `PHP_VERSION` from file `/etc/hypernode/magweb.json`.
