### PR TITLE
expand docs with php8.1-xdebug and php8.0-xdebug

### DIFF
--- a/Documentation/debugging-with-xdebug-in-phpstorm.md
+++ b/Documentation/debugging-with-xdebug-in-phpstorm.md
@@ -33,6 +33,16 @@ Inside the docker, install php-xdebug.
 apt-get install php-xdebug
 ```
 
+Or if you are running PHP 8.0 you need to install:
+```
+apt-get install php8.0-xdebug
+```
+
+And for PHP 8.1:
+```
+apt-get install php8.1-xdebug
+```
+
 Note: if you're doing this manually all the time consider making a Dockerfile based on `hypernode-docker` that does this as part of the image.
 
 Enable `php-xdebug` for `php-fpm`


### PR DESCRIPTION
the version of php-xdebug we have in our repos doesn't support the
latest PHP versions. in the newer php-xdebug older PHP versions that we
still want to have as dockers here are dropped, so instead there are
separate packages like php8.1-xdebug and php8.0-xdebug for those PHP
versions.

looks like:
```
# docker run docker.hypernode.com/byteinternet/hypernode-buster-docker-php80-mysql80:latest
...
# ssh root@172.17.0.2
root@08b999aca99a ~ # 
root@08b999aca99a ~ # apt-get update
root@08b999aca99a ~ # apt-get install php8.1-xdebug
root@08b999aca99a ~ # dpkg -L php8.1-xdebug
/.
/etc
/etc/php
/etc/php/8.1
/etc/php/8.1/mods-available
/etc/php/8.1/mods-available/xdebug.ini
/usr
/usr/lib
/usr/lib/php
/usr/lib/php/20210902
/usr/lib/php/20210902/xdebug.so
/usr/share
/usr/share/doc
/usr/share/doc/php8.1-xdebug
/usr/share/doc/php8.1-xdebug/changelog.Debian.gz
/usr/share/doc/php8.1-xdebug/copyright
root@08b999aca99a ~ # php8.1 -m | grep xdebug -i
xdebug
Xdebug
```