### PR TITLE
fix build command in README for linux devenv

### DIFF
--- a/examples/linux_development/README.md
+++ b/examples/linux_development/README.md
@@ -5,7 +5,8 @@
 ### Pull and run container
 
 ```
-docker build -t hypernode-docker-develop
+cd examples/linux_development
+docker build -t hypernode-docker-develop .
 docker run -d -p 3306:3306 -p 22:22 -p 80:80 -p 443:443 -p 8025:8025 -p 9200:9200 -v <local_path>:/data/web/magento --name hypernode-docker-develop
 ```
 


### PR DESCRIPTION
fixes the build instructions

before:
```
$ docker build -t hypernode-docker-develop
"docker build" requires exactly 1 argument.
See 'docker build --help'.

Usage:  docker build [OPTIONS] PATH | URL | -

Build an image from a Dockerfile
[vdloo@workstation5 hypernode-docker]$ cd examples/linux_development/
[vdloo@workstation5 linux_development]$ docker build -t hypernode-docker-develop
"docker build" requires exactly 1 argument.
See 'docker build --help'.

Usage:  docker build [OPTIONS] PATH | URL | -

Build an image from a Dockerfile
```
after:
```
$ docker build -t hypernode-docker-develop .
Sending build context to Docker daemon  8.192kB
Step 1/27 : FROM docker.hypernode.com/byteinternet/hypernode-buster-docker-php81-mysql80:latest
 ---> 8ea48550e534
Step 2/27 : MAINTAINER heesbeen
 ---> Running in a3cae03908a2
Removing intermediate container a3cae03908a2
 ---> e17520a9c243
```